### PR TITLE
feat(commands): Add command modules and sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,25 @@ The audience for this document includes:
 
 3. The `viki` CLI application allows the DevSecOps to create a YAML configuration file that specifies the desired outcome for a server, and stores the current state in a JSON state file.
 
-4. The priority in which mods are created is the same as the configuration file, however, in reverse when destroyed. Alternatively, you can set `mod.<mod_name>.precedence` to a value between `1` (highest) and `9` (lowest) for priority of creation.
+4. The `viki` CLI application allows the Developer to manage command modules, without editing the Python code, by using dictionary constants `DATA_COMMAND` and `MODS_COMMAND`.
+  * `DATA_COMMAND` is defined as a JSON object with `<MOD>` and `<CMD>` pairs.
+  * `MODS_COMMAND` is defined as a JSON object with `<MOD>` and `{ "insert": "<CMD>", "remove", "<CMD>" }` pairs.
 
-## 2.2. Workflow
+5. The `viki` CLI application supports `sudo` command with both password and passwordless authentication. When `sudo_password` is set to a non-empty string value, password authentication is used instead of passwordless.
+
+## 2.2. Limitations
+
+This project has several limitations.
+
+* No dependencies between modules and instances of modules.
+* You cannot perform an `update` to your resource.
+  * You should `destroy` your current resource and `add` a new one.
+* No priority when resources are created or destroyed during the `apply` stage.
+  * A workaround is to create your configuration files in order, e.g. `01.vk.yaml`, `02.vk.yaml`, and to remove them in the reverse order.
+* No support for local server.
+  * TODO: When `hostname` is set to `localhost`, the commands will be applied to the current workstation.
+
+## 2.3. Workflow
 
 This project uses several methods and products to optimize your workflow.
 
@@ -38,7 +54,7 @@ This project uses several methods and products to optimize your workflow.
 * Use a linter (**check-jsonschema**) to lint the rules YAML file.
 * Use a containerization platform (**Docker**) to run your application in any environment.
 
-## 2.3. Security
+## 2.4. Security
 
 This project has the following security.
 
@@ -46,7 +62,7 @@ This project has the following security.
   * A `<var_name>` associated with an environment variable `VK_VAR_<var_name>` will use that value.
 
 
-## 2.4. `viki` CLI Application
+## 2.5. `viki` CLI Application
 
 The `viki` CLI application has several commands:
   * A `fetch` command retrieves the outputs of data modules from a server and updates the JSON state file.
@@ -267,3 +283,16 @@ ok -- validation done
 ```
 
 </details>
+
+---
+# 8. References
+
+The following resources were used as a single-use reference.
+
+|                                         Title                                          |   Type   |   Author   |
+|:--------------------------------------------------------------------------------------:|:--------:|:----------:|
+| [Remote command execution in python using paramiko that supports arbitrary input][r02] |   Blog   | Joe Linoff |
+|                   [SSH Copy ID for Copying SSH Keys to Servers][r01]                   | Document |    SSH     |
+
+[r02]: https://joelinoff.com/blog/?p=905
+[r01]: https://www.ssh.com/academy/ssh/copy-id

--- a/app/common/apply_response.py
+++ b/app/common/apply_response.py
@@ -1,10 +1,14 @@
 from abc import ABC
 from common.base_response import BaseResponse
+from common.ssh_command import MODS_COMMAND, ssh_command
 
 class ApplyResponse(BaseResponse, ABC):
-  def __init__(self, logger, ssh, insert:dict, remove:dict, state:dict):
+  def __init__(self, logger, ssh, insert:dict, remove:dict, state:dict, vars:dict):
     self.log = logger
     self.log.fn = self.__class__.__name__ + '.' + self.__init__.__name__
+    self.sudo_password = None
+    if 'sudo_password' in vars and vars['sudo_password'] != '':
+      self.sudo_password = vars['sudo_password']
     self.ssh = ssh
     self.delta_insert = insert
     self.delta_remove = remove
@@ -15,24 +19,39 @@ class ApplyResponse(BaseResponse, ABC):
     state = {}
     for mod, names in self.delta_insert.items():
       state[mod] = {}
-      if mod == 'wget':
-        for name, param in names.items():
-          status, output = self.ssh.run('wget -O ' + param['output'] + ' ' + param['url'], None)
-          if status == 0:
-            self.state[mod][name] = param
-            self.log.info('{} : {}'.format(name, self.state[mod][name]))
-          else:
-            self.log.error('mod {} returned status code {}.'.format(mod, status))
+      cmd = MODS_COMMAND[mod]
+      for name, param in names.items():
+        self.log.info('{}'.format(ssh_command(cmd['insert'], param)))
+        exec = ssh_command(cmd['insert'], param, self.sudo_password)
+        if exec[:4] == "sudo":
+          status, output = self.ssh.run(exec, self.sudo_password)
+        else:
+          status, output = self.ssh.run(exec, None)
+
+        if status == 0:
+          if not mod in self.state:
+            self.state[mod] = {}
+          self.state[mod][name] = param
+          self.state[mod][name]['output'] = output
+          self.log.info('{} : {}'.format(name, self.state[mod][name]))
+        else:
+          self.log.error('mod {} returned status code {}.'.format(mod, status))
 
   def apply_remove(self):
     self.log.fn = self.__class__.__name__ + '.' + self.apply_remove.__name__
     for mod, names in self.delta_remove.items():
-      if mod == 'wget':
-        for name in names.keys():
-          if name in self.state[mod]:
-            status, output = self.ssh.run('rm ' + self.state[mod][name]['path'] + '/' + self.state[mod][name]['output'], None)
-            if status == 0:
-              self.log.info('{} : {}'.format(name, self.state[mod][name]))
-              del self.state[mod][name]
-            else:
-              self.log.error('mod {} returned status code {}.'.format(mod, status))
+      cmd = MODS_COMMAND[mod]
+      for name in names.keys():
+        if name in self.state[mod]:
+          self.log.info('{}'.format(ssh_command(cmd['remove'], self.state[mod][name])))
+          exec = ssh_command(cmd['remove'], self.state[mod][name], self.sudo_password)
+          if exec[:4] == "sudo":
+            status, output = self.ssh.run(exec, self.sudo_password)
+          else:
+            status, output = self.ssh.run(exec, None)
+
+          if status == 0:
+            self.log.info('{} : {}'.format(name, self.state[mod][name]))
+            del self.state[mod][name]
+          else:
+            self.log.error('mod {} returned status code {}:{}.'.format(mod, status, output))

--- a/app/common/fetch_response.py
+++ b/app/common/fetch_response.py
@@ -1,14 +1,16 @@
 from abc import ABC
 from common.base_response import BaseResponse
+from common.ssh_command import DATA_COMMAND, ssh_command
 
 class FetchResponse(BaseResponse, ABC):
-  def __init__(self, logger, ssh, config:dict):
+  def __init__(self, logger, ssh, config:dict, vars:dict):
     self.log = logger
     self.log.fn = self.__class__.__name__ + '.' + self.__init__.__name__
     self.ssh = ssh
-    unknown_mods = self.check_schema(config, schema={
-      'ls': {}
-    })
+    self.sudo_password = None
+    if 'sudo_password' in vars and vars['sudo_password'] != '':
+      self.sudo_password = vars['sudo_password']
+    unknown_mods = self.check_schema(config, schema=DATA_COMMAND)
     if unknown_mods != set():
       self.log.error('Unknown mods {} found in data.'.format(unknown_mods))
     self.config = config
@@ -19,12 +21,17 @@ class FetchResponse(BaseResponse, ABC):
     state = {}
     for mod, names in self.config.items():
       state[mod] = {}
-      if mod == 'ls':
-        for name, param in names.items():
-          status, output = self.ssh.run('ls -lAG ' + param['path'], None)
-          if status == 0:
-            state[mod][name] = param
-            state[mod][name]['output'] = output
-          else:
-            self.log.error('mod {} returned status code {}.'.format(mod, status))
+      cmd = DATA_COMMAND[mod]
+      for name, param in names.items():
+        self.log.info('{}'.format(ssh_command(cmd, param)))
+        exec = ssh_command(cmd, param, self.sudo_password)
+        if exec[:4] == "sudo":
+          status, output = self.ssh.run(exec, self.sudo_password)
+        else:
+          status, output = self.ssh.run(exec, None)
+        if status == 0:
+          state[mod][name] = param
+          state[mod][name]['output'] = output
+        else:
+          self.log.error('mod {} returned status code {}.'.format(mod, status))
     self.state = state

--- a/app/common/plan_response.py
+++ b/app/common/plan_response.py
@@ -1,14 +1,13 @@
 from abc import ABC
 from common.base_response import BaseResponse
+from common.ssh_command import MODS_COMMAND
 
 class PlanResponse(BaseResponse, ABC):
   def __init__(self, logger, ssh, config:dict, state:dict):
     self.log = logger
     self.log.fn = self.__class__.__name__ + '.' + self.__init__.__name__
     self.ssh = ssh
-    unknown_mods = self.check_schema(config, schema={
-      'wget': {}
-    })
+    unknown_mods = self.check_schema(config, schema=MODS_COMMAND)
     if unknown_mods != set():
       self.log.error('Unknown modules {} found in mods.'.format(unknown_mods))
     self.config = config

--- a/app/common/ssh_command.py
+++ b/app/common/ssh_command.py
@@ -1,0 +1,41 @@
+DATA_COMMAND={
+  "df": "df -h",
+  "docker": "sudo docker ps",
+  "ls": "ls ${path}",
+  "lsl": "ls -lAG ${path}"
+}
+
+MODS_COMMAND={
+  "mkdir": {
+    "insert": "sudo mkdir -p ${path}",
+    "remove": "sudo rmdir ${path}"
+  },
+  "wget": {
+    "insert": "wget -O ${path}/${output} ${url}",
+    "remove": "rm ${path}/${output}"
+  }
+}
+
+def ssh_command(command: str, config_param: dict, sudo_password: str = None) -> str:
+  '''
+  Replace placeholders in ssh command with configuration parameters.
+
+  Here is an example of a command, config_param and return value:
+
+    command             "ls -lAG ${path}"
+    config_param        { "path" : "~" }
+    returns             "ls -lAG ~"
+
+  @param command        The command with placeholders to substitute.
+  @param config_param   The configuration parameters.
+  @param sudo_password  Used for sudo password authentication. (Default: None for passwordless)
+  @returns              The ssh command to run with actual values.
+  '''
+  ret = command
+  if ret[:4] == "sudo" and not sudo_password is None:
+    if len(sudo_password)>0:
+      ret = "echo " + sudo_password + " | " + ret[:4] + " -S " + ret[5:]
+  for key, val in config_param.items():
+    sub = '${' + key + '}'
+    ret = ret.replace(sub, val)
+  return ret


### PR DESCRIPTION
Reason:
* Allows the Developer to manage command modules, without editing the Python code, by using dictionary constants `DATA_COMMAND` and `MODS_COMMAND`.
  * `DATA_COMMAND` is defined as a JSON object with `<MOD>` and `<CMD>` pairs.
  * `MODS_COMMAND` is defined as a JSON object with `<MOD>` and `{ "insert": "<CMD>", "remove", "<CMD>" }` pairs.

* Supports `sudo` command with both password and passwordless authentication. When `sudo_password` is set to a non-empty string value, password authentication is used instead of passwordless.

Limitation:
* No support for local server.
  * TODO: When `hostname` is set to `localhost`, the commands will be applied to the current workstation.
